### PR TITLE
feat: Add better error handling to rule creation

### DIFF
--- a/util/test_environment_preparer.js
+++ b/util/test_environment_preparer.js
@@ -116,13 +116,7 @@ export const createTopicRule = async (sqlUnderTest, sqlVersion, ruleName, topic,
         }
     };
     const command = new CreateTopicRuleCommand(input);
-    try {
-        const response =  await client.send(command);
-        return (response.$metadata.httpStatusCode === 200);
-    } catch (e) {
-        return false;
-    }
-    //TODO: parse errors.
+    return  await client.send(command);
 }
 
 const deleteTopicRule = async (ruleName) => {

--- a/validation/validate-iot-rules.test.js
+++ b/validation/validate-iot-rules.test.js
@@ -110,8 +110,9 @@ describe('Verify IoT Rule Test Suite', () => {
         const ruleName = 'TestRule_' + generateRandomString();
         const res = await retry(async (bail) => {
             const sqlVersionString = sqlVersion ? sqlVersion : '2016-03-23';
+            let result = null;
             try {
-                const result = await createTopicRule(inputSql, sqlVersionString, ruleName, REPUBLISH_TOPIC, rolePolicyInfo.roleArn);
+                result = await createTopicRule(inputSql, sqlVersionString, ruleName, REPUBLISH_TOPIC, rolePolicyInfo.roleArn);
             } catch (e) {
                 if(e instanceof InvalidRequestException) {
                     throw new Error('[Validate-IoT-Rules] Error creating rule. Might need to wait for the role to be persisted.')
@@ -132,7 +133,7 @@ describe('Verify IoT Rule Test Suite', () => {
                 console.log('[Validate-IoT-Rules] trying again to create the Rule... ');
             }
         });
-        expect(res).toBe(true);
+        expect(res?.$metadata?.httpStatusCode).toBe(200);
         rulesToCleanUp.push(ruleName);
 
         console.log('[Validate-IoT-Rules] ', new Date().toISOString(), ' Created IoT Rule', ruleName, res);


### PR DESCRIPTION
# What
Adds better error handling to rule creation

# Why
Currently SQL Parse Errors are never surfaced. If an SQL parse error occurs it is nicer behaviour that it is instantly surfaced.

# How
By capturing different error types and reporting on them accordingly